### PR TITLE
docs: Add documentation on how to use strict mode

### DIFF
--- a/_docs/advanced-topics.md
+++ b/_docs/advanced-topics.md
@@ -68,3 +68,40 @@ This paragraph needs to be written, want to help out? Checkout GitHub repo!
 
 ## Using custom error messages
 This paragraph needs to be written, want to help out? Checkout GitHub repo!
+
+# Validating using strict mode (Draft 6 only)
+```php
+<?php
+
+$data = json_decode(file_get_contents('data.json'));
+$jsonSchemaAsString = <<<'JSON'
+{
+  "$schema": "http://json-schema.org/draft-06/schema#",
+  "$id": "https://example.com/schemas/user.json",
+  "type": "object",
+  "properties": {
+    "name": { "type": "string" },
+    "email": { "type": "string" }
+  },
+  "required": ["name", "email"]
+}
+JSON;
+
+$jsonSchema = json_decode($jsonSchemaAsString);
+$schemaStorage = new JsonSchema\SchemaStorage();
+$schemaStorage->addSchema($jsonSchema->$id, $jsonSchema);
+$validator = new JsonSchema\Validator(
+    new JsonSchema\Constraints\Factory($schemaStorage)
+);
+$checkMode = Constraint::CHECK_MODE_NORMAL | Constraint::CHECK_MODE_STRICT;
+$validator->validate($data, $jsonSchemaObject, $checkMode);
+
+if ($validator->isValid()) {
+    echo "The supplied JSON validates against the schema.\n";
+} else {
+    echo "JSON does not validate. Violations:\n";
+    foreach ($validator->getErrors() as $error) {
+        printf("[%s] %s\n", $error['property'], $error['message']);
+    }
+}
+```

--- a/_docs/check-mode.md
+++ b/_docs/check-mode.md
@@ -29,17 +29,16 @@ $validator->validate(
 );
 ```
 
-
-
 ## Available flags
-| Flag                                            |   | Value        | Description                                                   |
-|-------------------------------------------------|:--|--------------|---------------------------------------------------------------|
-| `Constraint::CHECK_MODE_NORMAL`                 |   | `0x00000001` | Validate in 'normal' mode - this is the default               |
-| `Constraint::CHECK_MODE_TYPE_CAST`              |   | `0x00000002` | Enable fuzzy type checking for associative arrays and objects |
-| `Constraint::CHECK_MODE_COERCE_TYPES`           |   | `0x00000004` | Convert data types to match the schema where possible         |
-| `Constraint::CHECK_MODE_APPLY_DEFAULTS`         |   | `0x00000008` | Apply default values from the schema if not set               |
-| `Constraint::CHECK_MODE_EXCEPTIONS`             |   | `0x00000010` | Throw an exception immediately if validation fails            |
-| `Constraint::CHECK_MODE_DISABLE_FORMAT`         |   | `0x00000020` | Do not validate "format" constraints                          |
-| `Constraint::CHECK_MODE_EARLY_COERCE`           |   | `0x00000040` | Apply type coercion as soon as possible                       |
-| `Constraint::CHECK_MODE_ONLY_REQUIRED_DEFAULTS` |   | `0x00000080` | When applying defaults, only set values that are required     |
-| `Constraint::CHECK_MODE_VALIDATE_SCHEMA`        |   | `0x00000100` | Validate the schema as well as the provided document          |
+| Flag                                            |   | Value        | Description                                                              |
+|-------------------------------------------------|:--|--------------|--------------------------------------------------------------------------|
+| `Constraint::CHECK_MODE_NORMAL`                 |   | `0x00000001` | Validate in 'normal' mode - this is the default                          |
+| `Constraint::CHECK_MODE_TYPE_CAST`              |   | `0x00000002` | Enable fuzzy type checking for associative arrays and objects            |
+| `Constraint::CHECK_MODE_COERCE_TYPES`           |   | `0x00000004` | Convert data types to match the schema where possible                    |
+| `Constraint::CHECK_MODE_APPLY_DEFAULTS`         |   | `0x00000008` | Apply default values from the schema if not set                          |
+| `Constraint::CHECK_MODE_EXCEPTIONS`             |   | `0x00000010` | Throw an exception immediately if validation fails                       |
+| `Constraint::CHECK_MODE_DISABLE_FORMAT`         |   | `0x00000020` | Do not validate "format" constraints                                     |
+| `Constraint::CHECK_MODE_EARLY_COERCE`           |   | `0x00000040` | Apply type coercion as soon as possible                                  |
+| `Constraint::CHECK_MODE_ONLY_REQUIRED_DEFAULTS` |   | `0x00000080` | When applying defaults, only set values that are required                |
+| `Constraint::CHECK_MODE_VALIDATE_SCHEMA`        |   | `0x00000100` | Validate the schema as well as the provided document                     |
+| `Constraint::CHECK_MODE_STRICT`                 |   | `0x00000200` | Validate the schema using strict mode, respecting the $schema identifier |


### PR DESCRIPTION
This PR adds documentation for the Draft 6 support which is being prepared in https://github.com/jsonrainbow/json-schema/pull/835